### PR TITLE
Export extensions configuration to separate file.

### DIFF
--- a/extensions.txt
+++ b/extensions.txt
@@ -1,0 +1,37 @@
+# In this file, all possible extensions for rom-files should be defined
+[Nintendo Entertainment System]
+extensions=
+
+[Super Nintendo]
+extensions=smc
+
+[Nintendo 64]
+extensions=
+
+[Nintendo Gamecube]
+extensions=
+
+[Nintendo Wii]
+extensions=iso
+
+[Playstation 1]
+extensions=
+
+[Playstation 2]
+extensions=
+
+[Sega Genesis]
+extensions=
+
+[Sega Dreamcast]
+extensions=
+
+[Nintendo Gameboy]
+extensions=
+
+[Gameboy Advance]
+extensions=
+
+[Nintendo DS]
+extensions=
+

--- a/ice/console.py
+++ b/ice/console.py
@@ -29,14 +29,16 @@ class Console():
     def settings_consoles(self):
         consoles = []
         consoles_dict = settings.consoles()
+        extensions_dict = settings.extensions()
         for name in consoles_dict.keys():
             console_data = consoles_dict[name]
+            extension_data = extensions_dict[name]
             nickname = name
             if 'nickname' in console_data:
                 nickname = console_data['nickname']
             extensions = ""
-            if 'extensions' in console_data:
-    	        extensions = console_data['extensions']
+            if 'extensions' in extension_data:
+                extensions = extension_data['extensions']
             console = Console(nickname, name, extensions)
             consoles.append(console)
         return consoles

--- a/ice/settings.py
+++ b/ice/settings.py
@@ -18,6 +18,7 @@ appauthor = "Scott Rice"
 config_dict = None
 consoles_dict = None
 emulators_dict = None
+extensions_dict= None
 
 def user_settings_path():
   return "config.txt"
@@ -27,6 +28,9 @@ def user_consoles_path():
 
 def user_emulators_path():
   return "emulators.txt"
+
+def user_extensions_path():
+    return "extensions.txt"
 
 def _config_file_to_dictionary(path):
   config = ConfigParser.ConfigParser()
@@ -56,9 +60,17 @@ def emulators():
     emulators_dict = _config_file_to_dictionary(user_emulators_path())
   return emulators_dict
 
+def extensions():
+  global extensions_dict
+  if extensions_dict == None:
+    extensions_dict = _config_file_to_dictionary(user_extensions_path())
+  return extensions_dict
+
+
 def settings_for_file(file):
   return {
     "config.txt": config(),
     "consoles.txt": consoles(),
     "emulators.txt": emulators(),
+    "extensions.txt": extensions()
   }[file]


### PR DESCRIPTION
This way the consoles.txt or config.txt doesn't get cluttered with lists of extensions.
