### PR TITLE
More string normalization. Should fix #121

### DIFF
--- a/ice/steam_shortcut_manager.py
+++ b/ice/steam_shortcut_manager.py
@@ -9,7 +9,7 @@ Copyright (c) 2012 Scott Rice. All rights reserved.
 
 import sys
 import os
-
+import unicodedata
 import re
 
 x00 = u'\x00'
@@ -20,7 +20,7 @@ x0a = u'\x0a'
 class SteamShortcut:
     def __init__(self,appname,exe,startdir,icon,tag):
         self.appname = appname
-        self.exe = exe
+        self.exe = unicodedata.normalize('NFKD', unicode(exe.decode('utf-8'))).encode('ascii', 'ignore')
         self.startdir = startdir
         self.icon = icon
         self.tag = tag


### PR DESCRIPTION
Found yet another place that needed some string normalization.

It should be said, that this normalization removes symbols such as "©" and "®" from the game name, so that "LEGO® Something Something" will end up as "LEGO Something Something" in Steam.

This commit fixes the crashing problem on my end, however.
