### PR TITLE
More descriptive error messages, for when Steam is not found

### DIFF
--- a/ice/steam_installation_location_manager.py
+++ b/ice/steam_installation_location_manager.py
@@ -26,14 +26,24 @@ def windows_steam_location():
 def windows_userdata_location():
     # On Windows, the userdata directory is the steam installation directory
     # with 'userdata' appeneded
-    return os.path.join(windows_steam_location(),"userdata")
+    try:
+        out = os.path.join(windows_steam_location(),"userdata")
+    except WindowsError, e:
+        raise IOError("Steam installation not found")
+    return out
 
 def osx_userdata_location():
     # I'm pretty sure the user can't change this on OS X. I think it always
     # goes to the same location
-    return os.path.expanduser(osx_userdata_directory)
+    out = os.path.expanduser(osx_userdata_directory)
+    if not os.path.exists(out):
+        raise IOError("Steam userdata directory not found in the default location:\n" + out)
+    return out
 
 def linux_userdata_location():
-    return os.path.expanduser(linux_userdata_directory)
+    out = os.path.expanduser(linux_userdata_directory)
+    if not os.path.exists(out):
+        raise IOError("Steam userdata directory not found in the default location:\n" + out)
+    return out
 
 steam_userdata_location = pf.platform_specific(windows=windows_userdata_location, osx=osx_userdata_location, linux=linux_userdata_location)


### PR DESCRIPTION
This should work on all platforms. 

The old error messages were vague and required digging into the logs and source code to find out what went wrong. The new messages say "Steam installation not found" on Windows, and "Steam userdata directory not found in the default location:" on Linux and OSX along with the path Ice looked in.

I think the user should be given the option to give Ice the correct path when one of these errors occurs, or quit. That should make it a little more user friendly while we don't have a GUI.
