### PR TITLE
Config.txt entry for Steam directory

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -17,3 +17,15 @@ ROMs Directory=
 #
 # If this field is left blank, Ice will not attempt to download images
 Source=consolegrid.com/api/top_picture
+
+[Steam]
+# Leave this field blank unless Ice can't find Steam.
+#
+# The directory for Steam's userdata folder. This can be in any local drive or directory,
+# as long as the full path is specified. Use ~ to represent your home folder
+# (for example, C:\Users\Scott\)
+#
+# It is located in Steam's installation directory on Windows (ex. C:\Program Files\Steam\userdata).
+# It is generally located at ~/Library/Application Support/Steam/userdata/ on OSX and
+# ~/.local/share/Steam/userdata/ on Linux.
+Userdata Directory=

--- a/ice/steam_installation_location_manager.py
+++ b/ice/steam_installation_location_manager.py
@@ -13,10 +13,14 @@ shortcuts.vdf file, which is obviously useful for Ice
 import os
 
 import platform_helper as pf
+import settings
 
 # Used to find the shortcuts.vdf file
 osx_userdata_directory = "~/Library/Application Support/Steam/userdata/"
 linux_userdata_directory = "~/.local/share/Steam/userdata/"
+
+def config_userdata_location():
+    return os.path.expanduser(settings.config()["Steam"]["userdata directory"])
 
 def windows_steam_location():
     import _winreg as registry
@@ -25,25 +29,37 @@ def windows_steam_location():
 
 def windows_userdata_location():
     # On Windows, the userdata directory is the steam installation directory
-    # with 'userdata' appeneded
-    try:
-        out = os.path.join(windows_steam_location(),"userdata")
-    except WindowsError, e:
-        raise IOError("Steam installation not found")
+    # with 'userdata' appended
+    if config_userdata_location() == "":
+        try:
+            out = os.path.join(windows_steam_location(),"userdata")
+        except WindowsError:
+            raise IOError("Steam installation not found\n"
+                          "Please reinstall Steam or configure its userdata directory in config.txt")
+    else:
+        out = config_userdata_location()
     return out
 
 def osx_userdata_location():
     # I'm pretty sure the user can't change this on OS X. I think it always
     # goes to the same location
-    out = os.path.expanduser(osx_userdata_directory)
+    if config_userdata_location() == "":
+        out = os.path.expanduser(osx_userdata_directory)
+    else:
+        out = config_userdata_location()
     if not os.path.exists(out):
-        raise IOError("Steam userdata directory not found in the default location:\n" + out)
+        raise IOError("Steam userdata directory not found in location:\n" + out +
+                      "\nPlease configure Steam's userdata directory in config.txt")
     return out
 
 def linux_userdata_location():
-    out = os.path.expanduser(linux_userdata_directory)
+    if config_userdata_location() == "":
+        out = os.path.expanduser(linux_userdata_directory)
+    else:
+        out = config_userdata_location()
     if not os.path.exists(out):
-        raise IOError("Steam userdata directory not found in the default location:\n" + out)
+        raise IOError("Steam userdata directory not found in location:\n" + out +
+                      "\nPlease configure Steam's userdata directory in config.txt")
     return out
 
 steam_userdata_location = pf.platform_specific(windows=windows_userdata_location, osx=osx_userdata_location, linux=linux_userdata_location)


### PR DESCRIPTION
I've added an entry in config.txt for the Steam directory. Right now it will be used if it's set, or the directory will be auto detected if it's not.

I know there was a similar config entry before that was removed when the Windows registry key started being used, but I don't see any reason to completely remove it. This way the user will always have an option if the registry/hard coded folders fail, on any platform.
