### PR TITLE
Added a whitelist to console.py

### DIFF
--- a/consoles.txt
+++ b/consoles.txt
@@ -25,7 +25,7 @@
 #   Ice will add every file in the ROMs directory to Steam.
 #
 # Whitelist: *optional* A (comma separated) list of file names (including extensions) to 
-#   are ROMs. For example, if the value was set to ‘game1.zip, game2.zip’ then only
+#   assume are ROMs. For example, if the value was set to ‘game1.zip, game2.zip’ then only
 #   files that are named ‘game1.zip’ or ‘game2.zip’ will be added to Steam. If not
 #   provided, Ice will add every file in the ROMs directory to Steam.
 #

--- a/consoles.txt
+++ b/consoles.txt
@@ -24,6 +24,11 @@
 #   that ended with '.sfc' or '.smc' will be added to Steam. If not provided,
 #   Ice will add every file in the ROMs directory to Steam.
 #
+# Whitelist: *optional* A (comma separated) list of file names (including extensions) to 
+#   are ROMs. For example, if the value was set to ‘game1.zip, game2.zip’ then only
+#   files that are named ‘game1.zip’ or ‘game2.zip’ will be added to Steam. If not
+#   provided, Ice will add every file in the ROMs directory to Steam.
+#
 # ROMs Directory: *optional* If given a path, Ice will look in the specified
 #   directory for ROMs (instead of the one it generates).
 #
@@ -46,6 +51,7 @@
 # nickname=SNES
 # emulator=ZSNES
 # extensions=sfc, smc
+# whitelist=game1.zip, game2.zip
 # roms directory=C:\Games\Super Nintendo\ROMs
 # prefix=[SNES]
 # icon=C:\Games\Super Nintendo\icon.png

--- a/src/ice/console.py
+++ b/src/ice/console.py
@@ -30,6 +30,7 @@ class Console(BackedObject):
         self.fullname               = identifier
         self.shortname              = self.backed_value('nickname', self.fullname)
         self.extensions             = self.backed_value('extensions', "")
+        self.whitelist              = self.backed_value('whitelist', "")
         self.custom_roms_directory  = self.backed_value('roms directory', "")
         self.prefix                 = self.backed_value('prefix', "")
         self.icon                   = self.backed_value('icon', "")
@@ -71,6 +72,19 @@ class Console(BackedObject):
             return True
         extension = os.path.splitext(path)[1].lower()
         return any(extension == ('.'+x.strip().lower()) for x in self.extensions.split(','))
+    
+    def is_wanted_rom(self,path):
+        """
+        This function determines if a ROM is actually wanted.
+        If there aren't any entries in an console's whitelist, then it is assumed
+        all the ROMs are wanted.
+        Otherwise, only the files in the whitelist are managed by Ice.
+        """
+
+        if self.whitelist == "":
+            return True
+        whitelist = os.path.split(path)[1].lower()
+        return any(whitelist == (x.strip().lower()) for x in self.whitelist.split(','))
   
     def find_roms(self):
         """
@@ -89,7 +103,7 @@ class Console(BackedObject):
                 # accidently added as well
                 if not utils.is_windows() and filename.startswith('.'):
                     continue
-                if self.emulator is not None and not self.is_valid_rom(file_path):
+                if self.emulator is not None and not self.is_valid_rom(file_path) or not self.is_wanted_rom(file_path):
                     # TODO: Tell the user that we are ignoring this file
                     # TODO: Again, why the hell are we logging that here?????
                     continue


### PR DESCRIPTION
Added the ability to add a whitelist to a console in console.txt. If there is no whitelist, it is assumed all ROMs in the directory are wanted. Very useful for MAME ROM directories.