### PR TITLE
Fixed a reference issue that prevented Ice running.

### DIFF
--- a/src/ice/steam_grid_updater.py
+++ b/src/ice/steam_grid_updater.py
@@ -1,7 +1,3 @@
-
-from error import provider_error
-
-
 class SteamGridUpdater(object):
 
   def __init__(self, provider, logger):


### PR DESCRIPTION
After pulling the latest changes from scottrice@96ed6871803c03be938c018046334e54f757480d the following error is generated:

    Traceback (most recent call last):
      File "D:\Development\Ice\src\ice.py", line 7, in <module>
        from ice.runners import command_line_runner
      File "D:\Development\Ice\src\ice\runners\command_line_runner.py", line 8, in <module>
        from ice_engine import IceEngine
      File "D:\Development\Ice\src\ice\runners\ice_engine.py", line 24, in <module>
        from ice.steam_grid_updater import SteamGridUpdater
      File "D:\Development\Ice\src\ice\steam_grid_updater.py", line 2, in <module>
        from error import provider_error
    ImportError: cannot import name provider_error

Looks like it's an issue with the *steam_grid_updater.py* file, and the following line:

```Python
from error import provider_error
```

Removing that line solves the issue.