### PR TITLE
Show process name on ProcessRunningError

### DIFF
--- a/ice/environment_checker.py
+++ b/ice/environment_checker.py
@@ -56,7 +56,7 @@ class EnvironmentChecker(object):
         p = psutil.Process(pid)
         if p.name().lower().startswith(program_name.lower()):
           return self.requirement_errors.append(
-              ProcessRunningError(program_name))
+              ProcessRunningError(p.name()))
       except Exception:
         continue
 


### PR DESCRIPTION
This allows for easier debugging of which process is blocking Ice from running. SteamOS has some processes which start with steam, but aren't steam.