### PR TITLE
Fix RetroArch command line arguments

### DIFF
--- a/_data/emulators.yml
+++ b/_data/emulators.yml
@@ -201,35 +201,35 @@ configurations:
         config: |
           [RetroArch Super Nintendo]
           location=/usr/bin/retroarch
-          command=%l -f -L "/usr/lib/libretro/snes9x_next_libretro.so" %r
+          command=%l -f --libretro="/usr/lib/libretro/snes9x_next_libretro.so" %r
 
           [RetroArch Nintendo DS]
           location=/usr/bin/retroarch
-          command=%l -f -L "/usr/lib/libretro/desmume_libretro.so" %r
+          command=%l -f --libretro="/usr/lib/libretro/desmume_libretro.so" %r
 
           [RetroArch Nintendo]
           location=/usr/bin/retroarch
-          command=%l -f -L "/usr/lib/libretro/fceumm_libretro.so" %r
+          command=%l -f --libretro="/usr/lib/libretro/fceumm_libretro.so" %r
 
           [RetroArch Gameboy Advance]
           location=/usr/bin/retroarch
-          command=%l -f -L "/usr/lib/libretro/vba_next_libretro.so" %r
+          command=%l -f --libretro="/usr/lib/libretro/vba_next_libretro.so" %r
 
           [RetroArch Sega Genesis]
           location=/usr/bin/retroarch
-          command=%l -f -L "/usr/lib/libretro/genesis_plus_gx_libretro.so" %r
+          command=%l -f --libretro="/usr/lib/libretro/genesis_plus_gx_libretro.so" %r
 
           [RetroArch Nintendo 64]
           location=/usr/bin/retroarch
-          command=%l -f -L "/usr/lib/libretro/mupen64plus_libretro.so" %r
+          command=%l -f --libretro="/usr/lib/libretro/mupen64plus_libretro.so" %r
 
           [RetroArch Sony Playstation]
           location=/usr/bin/retroarch
-          command=%l -f -L "/usr/lib/libretro/pcsx1_libretro.so" %r
+          command=%l -f --libretro="/usr/lib/libretro/pcsx1_libretro.so" %r
 
           [RetroArch Sony Playstation Portable]
           location=/usr/bin/retroarch
-          command=%l -f -L "/usr/lib/libretro/ppsspp_libretro.so" %r
+          command=%l -f --libretro="/usr/lib/libretro/ppsspp_libretro.so" %r
   # --------------------------------
   # Snes9x
   # --------------------------------


### PR DESCRIPTION
Using `--libretro=` is a bit more specific on which core to use.