### PR TITLE
Support ROMs with periods in the filename

### DIFF
--- a/ice/parsing/rom_parser.py
+++ b/ice/parsing/rom_parser.py
@@ -11,7 +11,7 @@ class ROMParser(object):
     # Regex that matches the entire string up until it hits the first '[',
     # ']', '(', ')', or '.'
     # DOESN'T WORK FOR GAMES WITH ()s IN THEIR NAME
-    ur"(?P<name>[^\(\)\[\]\.]*).*",
+    ur"(?P<name>[^\(\)\[\]]*).*",
   ]
 
   def __init__(self):
@@ -20,6 +20,7 @@ class ROMParser(object):
   def parse(self, path):
     """Parses the name of the ROM given its path."""
     filename = os.path.basename(path)
+    filename = os.path.splitext(filename)[0]
     opts = re.IGNORECASE
     match = reduce(lambda match, regex: match if match else re.match(regex, filename, opts), self.regexes, None)
     if match:

--- a/tests/rom_parser_tests.py
+++ b/tests/rom_parser_tests.py
@@ -22,6 +22,8 @@ class ROMFinderTests(unittest.TestCase):
     ("Shenmue 2 (PAL).iso" , "Shenmue 2"),
     ("Resident Evil Code Veronica (PAL) (UK).iso" , "Resident Evil Code Veronica"),
     ("Chrono Trigger (USA).sfc", "Chrono Trigger"),
+    ("Dr. Mario 64 (USA).z64", "Dr. Mario 64"),
+    ("Super Mario World (E) (V1.0).smc", "Super Mario World"),
     # TODO(Wishlist): I'd like to be able to remove the `Rev 1` from the filename, but that is much
     # more complicated than our current strategy of just matching against everything not in parens
     # ("Super Mario World 2 - Yoshi's Island Rev 1 (1995)(Nintendo)(US).sfc", "Super Mario World 2 - Yoshi's Island"),


### PR DESCRIPTION
I've added the ability to support filenames with a period in the name, such as **Dr. Mario 64.z64** -> **Dr. Mario 64** as the shortcut name in Steam as in issue #364. The current behaviour was to stop processing at the first instance of a period, or parens, yielding **Dr**.

We just use `os.path.splitext` on the base filename to remove the extension if it exists, and then process the result as usual with the exception of keeping the periods. Two test cases are added.