### PR TITLE
Allow streaming of roms with space in filename

### DIFF
--- a/ice/emulators.py
+++ b/ice/emulators.py
@@ -11,6 +11,7 @@ def emulator_rom_launch_command(emulator, rom):
   # so normalizing it then adding quotes should do what I want 100% of the time
   normalize = lambda s: s.strip("\"")
   add_quotes = lambda s: "\"%s\"" % s
+  add_rom_quotes = lambda s: "\"\"\"%s\"\"\"" % s
 
   # We don't know if the user put quotes around the emulator location. If
   # so, we dont want to add another pair and screw things up.
@@ -18,7 +19,7 @@ def emulator_rom_launch_command(emulator, rom):
   # The user didnt give us the ROM information, but screw it, I already
   # have some code to add quotes to a string, might as well use it.
   quoted_location = add_quotes(normalize(emulator.location))
-  quoted_rom      = add_quotes(normalize(rom.path))
+  quoted_rom      = add_rom_quotes(normalize(rom.path))
   # The format string contains a bunch of specifies that users can use to
   # substitute values in at runtime. Right now the only supported values are:
   # %l - The location of the emulator (to avoid sync bugs)


### PR DESCRIPTION
fix to wrap rom path in triple quotes to allow for steam in-home
streaming to stream rom files with spaces in path/filename

Resolves issue #288 
