### PR TITLE
Use updated pysteam version

### DIFF
--- a/ice/emulators.py
+++ b/ice/emulators.py
@@ -2,39 +2,48 @@
 
 import os
 
-def emulator_rom_launch_command(emulator, rom):
-  """Generates a command string that will launch `rom` with `emulator` (using
-  the format provided by the user). The return value of this function should
-  be suitable to use as the `Exe` field of a Steam shortcut"""
-  # Normalizing the strings is just removing any leading/trailing quotes.
-  # The beautiful thing is that strip does nothing if it doesnt contain quotes,
-  # so normalizing it then adding quotes should do what I want 100% of the time
-  normalize = lambda s: s.strip("\"")
-  add_quotes = lambda s: "\"%s\"" % s
 
-  # We don't know if the user put quotes around the emulator location. If
-  # so, we dont want to add another pair and screw things up.
-  #
-  # The user didnt give us the ROM information, but screw it, I already
-  # have some code to add quotes to a string, might as well use it.
-  quoted_location = add_quotes(normalize(emulator.location))
-  quoted_rom      = add_quotes(normalize(rom.path))
-  # The format string contains a bunch of specifies that users can use to
-  # substitute values in at runtime. Right now the only supported values are:
-  # %l - The location of the emulator (to avoid sync bugs)
-  # %r - The location of the ROM (so the emulator knows what to launch)
-  # %fn - The ROM filename without its extension (for emulators that utilize separete configuration files)
-  #
-  # More may be added in the future, but for now this is what we support
-  return (
-    emulator.format
-      .replace("%l", quoted_location)
-      .replace("%r", quoted_rom)
-      .replace("%fn", os.path.splitext(os.path.basename(rom.path))[0])
-  )
+def emulator_rom_exe(emulator):
+    """Generates a command string that will launch `emulator` (using
+    the format provided by the user). The return value of this function should
+    be suitable to use as the `Exe` field of a Steam shortcut"""
+
+    # We don't know if the user put quotes around the emulator location. If
+    # so, we dont want to add another pair and screw things up.
+    return normalize(emulator.location)
+
+
+def emulator_rom_launch_options(emulator, rom):
+    """Generates the launch options string that will launch `rom` with `emulator` (using
+    the format provided by the user). The return value of this function should
+    be suitable to use as the `LaunchOptions` field of a Steam shortcut"""
+
+    # The user didn't give us the ROM information, but screw it, I already
+    # have some code to add quotes to a string, might as well use it.
+    quoted_rom = normalize(rom.path)
+
+    # The format string contains a bunch of specifies that users can use to
+    # substitute values in at runtime. Right now the only supported values are:
+    # %r - The location of the ROM (so the emulator knows what to launch)
+    # %fn - The ROM filename without its extension (for emulators that utilize separate configuration files)
+    #
+    # More may be added in the future, but for now this is what we support
+    return (emulator.format
+            .replace("%r", quoted_rom)
+            .replace("%fn", os.path.splitext(os.path.basename(rom.path))[0])
+            )
+
 
 def emulator_startdir(emulator):
-  """Returns the directory which stores the emulator. The return value of this
-  function should be suitable to use as the 'StartDir' field of a Steam
-  shortcut"""
-  return os.path.dirname(emulator.location)
+    """Returns the directory which stores the emulator. The return value of this
+    function should be suitable to use as the 'StartDir' field of a Steam
+    shortcut"""
+    return os.path.dirname(emulator.location)
+
+
+def normalize(string):
+    """Normalizing the strings is just removing any leading/trailing quotes.
+    The beautiful thing is that strip does nothing if it doesnt contain quotes,
+    so normalizing it then adding quotes should do what I want 100% of the time
+    """
+    return "\"%s\"" % string.strip("\"")

--- a/ice/persistence/adapters/emulator_adapter.py
+++ b/ice/persistence/adapters/emulator_adapter.py
@@ -12,7 +12,8 @@ class EmulatorBackedObjectAdapter(object):
   def new(self, backing_store, identifier):
     name     = identifier
     location = backing_store.get(identifier, 'location')
-    fmt      = backing_store.get(identifier, 'command', "%l %r")
+    # fmt      = backing_store.get(identifier, 'command', "%l %r")
+    fmt      = backing_store.get(identifier, 'command', "%r")
 
     location = os.path.expanduser(location)
 

--- a/ice/roms.py
+++ b/ice/roms.py
@@ -46,9 +46,15 @@ def rom_to_shortcut(rom):
   assert(emu is not None)
 
   return model.Shortcut(
-    name      = rom_shortcut_name(rom),
-    exe       = emulators.emulator_rom_launch_command(emu, rom),
-    startdir  = emulators.emulator_startdir(emu),
-    icon      = rom.console.icon,
-    tags      = [rom.console.fullname]
+    name                 = rom_shortcut_name(rom),
+    exe                  = emulators.emulator_rom_exe(emu),
+    startdir             = emulators.emulator_startdir(emu),
+    icon                 = rom.console.icon,
+    shortcut_path        ='',
+    launch_options       = emulators.emulator_rom_launch_options(emu, rom),
+    hidden               = False,
+    allow_desktop_config = False,
+    open_vr              = False,
+    last_play_time       = 0,
+    tags                 = [rom.console.fullname]
   )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 appdirs==1.2.0
 pastebin==1.1.0
 psutil==2.1.1
-pysteam==1.0.0-beta2
+pysteam==1.1.0-beta2

--- a/tests/backups_tests.py
+++ b/tests/backups_tests.py
@@ -71,7 +71,7 @@ class BackupsTests(unittest.TestCase):
 
     user = self.user_fixture.get_context()
 
-    shortcut = model.Shortcut('Plex', '/Path/to/plex', '/Path/to', '', [])
+    shortcut = model.Shortcut('Plex', '/Path/to/plex', '/Path/to', '', '', '', False, False, False, 0, [])
     user_shortcuts = [shortcut]
 
     shortcuts.set_shortcuts(user, user_shortcuts)

--- a/tests/emulators_tests.py
+++ b/tests/emulators_tests.py
@@ -12,7 +12,7 @@ from ice import model
 class EmulatorsTests(unittest.TestCase):
 
   @parameterized.expand([
-    ("C:/emu.exe", "C:"),
+    ("C:/emu.exe", "C:/"),
     ("C:/Path/to/emulator.exe", "C:/Path/to"),
     ("/emu", "/"),
     ("/path/to/emulator", "/path/to"),
@@ -22,15 +22,15 @@ class EmulatorsTests(unittest.TestCase):
     self.assertEqual(emulators.emulator_startdir(emu), expected)
 
   @parameterized.expand([
-    ("%l %r", "/emu", "/ROMs/rom", "\"/emu\" \"/ROMs/rom\""),
+    ("%r", "/emu", "/ROMs/rom", "\"/ROMs/rom\""),
     # Locations that contain quotes
-    ("%l %r", "\"/emu\"", "/ROMs/rom", "\"/emu\" \"/ROMs/rom\""),
+    ("%r", "\"/emu\"", "/ROMs/rom", "\"/ROMs/rom\""),
   ])
-  def test_emulator_rom_launch_command(self, fmt, location, rompath, expected):
+  def test_emulator_rom_launch_options(self, fmt, location, rompath, expected):
     emu = model.Emulator("Mednafen", location, fmt)
     r = model.ROM(
       name = "ROM",
       path = rompath,
       console = mock(),
     )
-    self.assertEqual(emulators.emulator_rom_launch_command(emu, r), expected)
+    self.assertEqual(emulators.emulator_rom_launch_options(emu, r), expected)

--- a/tests/integration/smoke_tests.py
+++ b/tests/integration/smoke_tests.py
@@ -24,7 +24,7 @@ class SmokeTests(unittest.TestCase):
     self.env.load_test_data(os.path.join("smoke", "adding_single_rom"))
     u1 = self.env.create_fake_user()
     u2 = self.env.create_fake_user()
-    u2_shortcut = model.Shortcut('Plex', '/Path/to/Plex', '/Path/to', '', [])
+    u2_shortcut = model.Shortcut('Plex', '/Path/to/Plex', '/Path/to', '', '', '', False, False, False, 0, [])
     preexisting_shortcuts = [u2_shortcut]
     self.env.set_user_shortcuts(u2, preexisting_shortcuts)
     self.env.run_command()

--- a/tests/integration/testdata/smoke/adding_single_rom/emulators.txt
+++ b/tests/integration/testdata/smoke/adding_single_rom/emulators.txt
@@ -1,4 +1,4 @@
 
 [Mednafen]
 location=/emu/Mednafen/mednafen
-command=%l %r
+command=%r

--- a/tests/integration/testdata/smoke/adding_single_rom/shortcuts-expected.json
+++ b/tests/integration/testdata/smoke/adding_single_rom/shortcuts-expected.json
@@ -1,9 +1,15 @@
 [
   {
     "name": "NESGame",
-    "exe": "\"/emu/Mednafen/mednafen\" \"%sb/ROMs/NES/NESGame.nes\"",
+    "exe": "\"/emu/Mednafen/mednafen\"",
     "startdir": "/emu/Mednafen",
     "icon": "",
+    "shortcut_path": "",
+    "launch_options": "\"%sb/ROMs/NES/NESGame.nes\"",
+    "hidden": false,
+    "allow_desktop_config": false,
+    "open_vr": false,
+    "last_play_time": 0,
     "tags": ["Nintendo Entertainment System"]
   }
 ]

--- a/tests/roms_tests.py
+++ b/tests/roms_tests.py
@@ -57,9 +57,15 @@ class ROMsTests(unittest.TestCase):
   @parameterized.expand([
     (fixtures.roms.banjo_kazooie, steam_model.Shortcut(
       name = '[NES] Banjo Kazooie',
-      exe = '\"/emulators/Mednafen/mednafen\" \"/roms/nes/Banjo Kazooie.nes\"',
+      exe = '\"/emulators/Mednafen/mednafen\"',
       startdir = '/emulators/Mednafen',
       icon = '/consoles/icons/nes.png',
+      shortcut_path ='',
+      launch_options ='\"/roms/nes/Banjo Kazooie.nes\"',
+      hidden = False,
+      allow_desktop_config = False,
+      open_vr = False,
+      last_play_time = 0,
       tags = ['Nintendo Entertainment System']
     ))
   ])

--- a/tests/steam_shortcut_synchronizer_tests.py
+++ b/tests/steam_shortcut_synchronizer_tests.py
@@ -39,7 +39,7 @@ class SteamShortcutSynchronizerTests(unittest.TestCase):
 
   def test_unmanaged_shortcuts_returns_all_shortcuts_when_given_no_history(self):
     dummy_console = self._create_dummy_console("/Some/Other/Path")
-    random_shortcut = steam_model.Shortcut("Plex", "/Some/Random/Path/plex", "/Some/Random/Path", "", [])
+    random_shortcut = steam_model.Shortcut("Plex", "/Some/Random/Path/plex", "/Some/Random/Path", "", "", "", False, False, False, 0, [])
 
     unmanaged = self.synchronizer.unmanaged_shortcuts(None ,[random_shortcut], [dummy_console])
 
@@ -47,7 +47,7 @@ class SteamShortcutSynchronizerTests(unittest.TestCase):
 
   def test_unmanaged_shortcuts_filters_suspicious_shortcuts_when_given_no_history(self):
     dummy_console = self._create_dummy_console("/Some/Path")
-    random_shortcut = steam_model.Shortcut("Iron Man", "/Some/Emulator/Path/emulator /Some/Path/Iron Man", "/Some/Emulator/Path", "", [])
+    random_shortcut = steam_model.Shortcut("Iron Man", "/Some/Emulator/Path/emulator /Some/Path/Iron Man", "/Some/Emulator/Path", "", "", "", False, False, False, 0, [])
 
     unmanaged = self.synchronizer.unmanaged_shortcuts(None ,[random_shortcut], [dummy_console])
 
@@ -55,77 +55,77 @@ class SteamShortcutSynchronizerTests(unittest.TestCase):
 
   def test_unmanaged_shortcuts_doesnt_filter_suspicious_shortcuts_when_we_have_history(self):
     dummy_console = self._create_dummy_console("/Some/Path")
-    random_shortcut = steam_model.Shortcut("Iron Man", "/Some/Emulator/Path/emulator /Some/Path/Iron Man", "/Some/Emulator/Path", "", [])
+    random_shortcut = steam_model.Shortcut("Iron Man", "/Some/Emulator/Path/emulator /Some/Path/Iron Man", "/Some/Emulator/Path", "", "", "", False, False, False, 0, [])
 
     unmanaged = self.synchronizer.unmanaged_shortcuts([] ,[random_shortcut], [dummy_console])
 
     self.assertEquals(unmanaged, [random_shortcut])
 
   def test_unmanaged_shortcuts_returns_shortcut_not_affiliated_with_ice(self):
-    random_shortcut = steam_model.Shortcut("Plex", "/Some/Random/Path/plex", "/Some/Random/Path", "", [])
+    random_shortcut = steam_model.Shortcut("Plex", "/Some/Random/Path/plex", "/Some/Random/Path", "", "", "", False, False, False, 0, [])
     unmanaged = self.synchronizer.unmanaged_shortcuts([],[random_shortcut], None)
     self.assertEquals(unmanaged, [random_shortcut])
 
   def test_unmanaged_shortcuts_doesnt_return_shortcut_with_flag_tag(self):
-    tagged_shortcut = steam_model.Shortcut("Game", "/Path/to/game", "/Path/to", "", [roms.ICE_FLAG_TAG])
+    tagged_shortcut = steam_model.Shortcut("Game", "/Path/to/game", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
     unmanaged = self.synchronizer.unmanaged_shortcuts([],[tagged_shortcut], None)
     self.assertEquals(unmanaged, [])
 
   def test_unmanaged_shortcuts_doesnt_return_shortcut_with_appid_in_managed_ids(self):
-    managed_shortcut = steam_model.Shortcut("Game", "/Path/to/game", "/Path/to", "", [])
-    random_shortcut = steam_model.Shortcut("Plex", "/Some/Random/Path/plex", "/Some/Random/Path", "", [])
+    managed_shortcut = steam_model.Shortcut("Game", "/Path/to/game", "/Path/to", "", "", "", False, False, False, 0, [])
+    random_shortcut = steam_model.Shortcut("Plex", "/Some/Random/Path/plex", "/Some/Random/Path", "", "", "", False, False, False, 0, [])
     managed_ids = [shortcuts.shortcut_app_id(managed_shortcut)]
     all_shortcuts = [managed_shortcut, random_shortcut]
     unmanaged = self.synchronizer.unmanaged_shortcuts(managed_ids, all_shortcuts, None)
     self.assertEquals(unmanaged, [random_shortcut])
 
   def test_added_shortcuts_doesnt_return_shortcuts_that_still_exist(self):
-    shortcut1 = steam_model.Shortcut("Game1", "/Path/to/game1", "/Path/to", "", [roms.ICE_FLAG_TAG])
-    shortcut2 = steam_model.Shortcut("Game2", "/Path/to/game2", "/Path/to", "", [roms.ICE_FLAG_TAG])
+    shortcut1 = steam_model.Shortcut("Game1", "/Path/to/game1", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
+    shortcut2 = steam_model.Shortcut("Game2", "/Path/to/game2", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
     old = [shortcut1, shortcut2]
     new = [shortcut1, shortcut2]
     self.assertEquals(self.synchronizer.added_shortcuts(old, new), [])
 
   def test_added_shortcuts_returns_shortcuts_that_didnt_exist_previously(self):
-    shortcut1 = steam_model.Shortcut("Game1", "/Path/to/game1", "/Path/to", "", [roms.ICE_FLAG_TAG])
-    shortcut2 = steam_model.Shortcut("Game2", "/Path/to/game2", "/Path/to", "", [roms.ICE_FLAG_TAG])
+    shortcut1 = steam_model.Shortcut("Game1", "/Path/to/game1", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
+    shortcut2 = steam_model.Shortcut("Game2", "/Path/to/game2", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
     new = [shortcut1, shortcut2]
     self.assertEquals(self.synchronizer.added_shortcuts([], new), [shortcut1, shortcut2])
 
   def test_added_shortcuts_only_returns_shortcuts_that_exist_now_but_not_before(self):
-    shortcut1 = steam_model.Shortcut("Game1", "/Path/to/game1", "/Path/to", "", [roms.ICE_FLAG_TAG])
-    shortcut2 = steam_model.Shortcut("Game2", "/Path/to/game2", "/Path/to", "", [roms.ICE_FLAG_TAG])
-    shortcut3 = steam_model.Shortcut("Game3", "/Path/to/game3", "/Path/to", "", [roms.ICE_FLAG_TAG])
-    shortcut4 = steam_model.Shortcut("Game4", "/Path/to/game4", "/Path/to", "", [roms.ICE_FLAG_TAG])
+    shortcut1 = steam_model.Shortcut("Game1", "/Path/to/game1", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
+    shortcut2 = steam_model.Shortcut("Game2", "/Path/to/game2", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
+    shortcut3 = steam_model.Shortcut("Game3", "/Path/to/game3", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
+    shortcut4 = steam_model.Shortcut("Game4", "/Path/to/game4", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
     old = [shortcut1, shortcut2]
     new = [shortcut1, shortcut2, shortcut3, shortcut4]
     self.assertEquals(self.synchronizer.added_shortcuts(old, new), [shortcut3, shortcut4])
 
   def test_removed_shortcuts_doesnt_return_shortcuts_that_still_exist(self):
-    shortcut1 = steam_model.Shortcut("Game1", "/Path/to/game1", "/Path/to", "", [roms.ICE_FLAG_TAG])
-    shortcut2 = steam_model.Shortcut("Game2", "/Path/to/game2", "/Path/to", "", [roms.ICE_FLAG_TAG])
+    shortcut1 = steam_model.Shortcut("Game1", "/Path/to/game1", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
+    shortcut2 = steam_model.Shortcut("Game2", "/Path/to/game2", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
     old = [shortcut1, shortcut2]
     new = [shortcut1, shortcut2]
     self.assertEquals(self.synchronizer.removed_shortcuts(old, new), [])
 
   def test_removed_shortcuts_returns_shortcuts_that_dont_exist_anymore(self):
-    shortcut1 = steam_model.Shortcut("Game1", "/Path/to/game1", "/Path/to", "", [roms.ICE_FLAG_TAG])
-    shortcut2 = steam_model.Shortcut("Game2", "/Path/to/game2", "/Path/to", "", [roms.ICE_FLAG_TAG])
+    shortcut1 = steam_model.Shortcut("Game1", "/Path/to/game1", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
+    shortcut2 = steam_model.Shortcut("Game2", "/Path/to/game2", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
     old = [shortcut1, shortcut2]
     new = []
     self.assertEquals(self.synchronizer.removed_shortcuts(old, new), [shortcut1, shortcut2])
 
   def test_removed_shortcuts_only_returns_shortcuts_that_dont_exist_now_but_did_before(self):
-    shortcut1 = steam_model.Shortcut("Game1", "/Path/to/game1", "/Path/to", "", [roms.ICE_FLAG_TAG])
-    shortcut2 = steam_model.Shortcut("Game2", "/Path/to/game2", "/Path/to", "", [roms.ICE_FLAG_TAG])
-    shortcut3 = steam_model.Shortcut("Game3", "/Path/to/game3", "/Path/to", "", [roms.ICE_FLAG_TAG])
-    shortcut4 = steam_model.Shortcut("Game4", "/Path/to/game4", "/Path/to", "", [roms.ICE_FLAG_TAG])
+    shortcut1 = steam_model.Shortcut("Game1", "/Path/to/game1", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
+    shortcut2 = steam_model.Shortcut("Game2", "/Path/to/game2", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
+    shortcut3 = steam_model.Shortcut("Game3", "/Path/to/game3", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
+    shortcut4 = steam_model.Shortcut("Game4", "/Path/to/game4", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
     old = [shortcut1, shortcut2, shortcut3, shortcut4]
     new = [shortcut1, shortcut2]
     self.assertEquals(self.synchronizer.removed_shortcuts(old, new), [shortcut3, shortcut4])
 
   def test_sync_roms_for_user_keeps_unmanaged_shortcuts(self):
-    random_shortcut = steam_model.Shortcut("Plex", "/Some/Random/Path/plex", "/Some/Random/Path", "", [])
+    random_shortcut = steam_model.Shortcut("Plex", "/Some/Random/Path/plex", "/Some/Random/Path", "", "", "", False, False, False, 0, [])
     self._set_users_shortcuts([random_shortcut])
     when(self.mock_archive).previous_managed_ids(self.user_fixture.get_context()).thenReturn([])
 
@@ -173,16 +173,16 @@ class SteamShortcutSynchronizerTests(unittest.TestCase):
     verify(self.mock_logger, times=3).info(any())
 
   def test_sync_roms_for_user_logs_when_a_rom_is_removed(self):
-    shortcut = steam_model.Shortcut("Game", "/Path/to/game", "/Path/to", "", [roms.ICE_FLAG_TAG])
+    shortcut = steam_model.Shortcut("Game", "/Path/to/game", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
     self._set_users_shortcuts([shortcut])
 
     self.synchronizer.sync_roms_for_user(self.user_fixture.get_context(), [], None)
     verify(self.mock_logger).info(any())
 
   def test_sync_roms_for_user_logs_once_for_each_removed_rom(self):
-    shortcut1 = steam_model.Shortcut("Game1", "/Path/to/game1", "/Path/to", "", [roms.ICE_FLAG_TAG])
-    shortcut2 = steam_model.Shortcut("Game2", "/Path/to/game2", "/Path/to", "", [roms.ICE_FLAG_TAG])
-    shortcut3 = steam_model.Shortcut("Game3", "/Path/to/game3", "/Path/to", "", [roms.ICE_FLAG_TAG])
+    shortcut1 = steam_model.Shortcut("Game1", "/Path/to/game1", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
+    shortcut2 = steam_model.Shortcut("Game2", "/Path/to/game2", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
+    shortcut3 = steam_model.Shortcut("Game3", "/Path/to/game3", "/Path/to", "", "", "", False, False, False, 0, [roms.ICE_FLAG_TAG])
     self._set_users_shortcuts([shortcut1, shortcut2, shortcut3])
 
     self.synchronizer.sync_roms_for_user(self.user_fixture.get_context(), [], None)

--- a/tests/testinfra/fake_environment.py
+++ b/tests/testinfra/fake_environment.py
@@ -19,14 +19,20 @@ from ice.persistence.config_file_backing_store import ConfigFileBackingStore
 from fixtures import SteamFixture, UserFixture
 
 def json_to_shortcut(json):
-  for field in ["name", "exe", "startdir", "icon", "tags"]:
+  for field in ["name", "exe", "startdir", "icon", "shortcut_path", "launch_options", "hidden", "allow_desktop_config", "open_vr", "last_play_time", "tags"]:
     assert field in json
   return model.Shortcut(
-    name      = json.get("name"),
-    exe       = json.get("exe"),
-    startdir  = json.get("startdir"),
-    icon      = json.get("icon"),
-    tags      = json.get("tags")
+    name                 = json.get("name").encode("UTF8"),
+    exe                  = json.get("exe").encode("UTF8"),
+    startdir             = json.get("startdir").encode("UTF8"),
+    icon                 = json.get("icon").encode("UTF8"),
+    shortcut_path        = json.get("shortcut_path").encode("UTF8"),
+    launch_options       = json.get("launch_options").encode("UTF8"),
+    hidden               = json.get("hidden"),
+    allow_desktop_config = json.get("allow_desktop_config"),
+    open_vr              = json.get("open_vr"),
+    last_play_time       = json.get("last_play_time"),
+    tags                 = json.get("tags")
   )
 
 class FakeEnvironment(object):
@@ -90,11 +96,17 @@ class FakeEnvironment(object):
 
   def _adjust_shortcut_exe(self, shortcut):
     return model.Shortcut(
-      name      = shortcut.name,
-      exe       = self._adjust_json_path(shortcut.exe),
-      startdir  = shortcut.startdir,
-      icon      = shortcut.icon,
-      tags      = shortcut.tags,
+      name                 = shortcut.name,
+      exe                  = self._adjust_json_path(shortcut.exe),
+      startdir             = shortcut.startdir,
+      icon                 = shortcut.icon,
+      shortcut_path        ='',
+      launch_options       = self._adjust_json_path(shortcut.launch_options.replace("/", os.sep)),
+      hidden               = False,
+      allow_desktop_config = False,
+      open_vr              = False,
+      last_play_time       = 0,
+      tags                 = shortcut.tags,
     )
 
   def load_test_data(self, testdata):

--- a/tests/testinfra/fixtures.py
+++ b/tests/testinfra/fixtures.py
@@ -81,7 +81,7 @@ emulators = DataFixture({
   "mednafen": model.Emulator(
     name = 'Mednafen',
     location = '/emulators/Mednafen/mednafen',
-    format = "%l %r"
+    format = "%r"
   ),
 })
 


### PR DESCRIPTION
Fix for: https://github.com/scottrice/Ice/issues/449

Update Ice to use new pysteam from: https://github.com/scottrice/pysteam/pull/14.

Now that the launch options field has been added to shortcuts.vdf Steam seems to bug out if you have parameters in the exe field.

This puts just the exe location in the "exe" field and the formatted command into "launch_options"

Also adds all the extra data to all the Shortcut tuples for tests etc