### PR TITLE
Added Retrogaming.cloud grid provider

### DIFF
--- a/ice/gridproviders/__init__.py
+++ b/ice/gridproviders/__init__.py
@@ -10,4 +10,5 @@ __all__ = [
     "consolegrid_provider",
     "grid_image_provider",
     "local_provider",
+    "retrogamingcloud_provider",
 ]

--- a/ice/gridproviders/retrogamingcloud_provider.py
+++ b/ice/gridproviders/retrogamingcloud_provider.py
@@ -42,7 +42,7 @@ class RetroGamingCloudProvider(grid_image_provider.GridImageProvider):
 
 	def rgc_search(self, rom):
 		api_root = self.api_url()
-		url = "%s?name=\"%s\"" % (api_root, rom.name)
+		url = "%s?name=%s" % (api_root, rom.name)
 		return self.rgc_get_result(url)
 
 	def rgc_get_media(self, game_id):
@@ -58,7 +58,7 @@ class RetroGamingCloudProvider(grid_image_provider.GridImageProvider):
 			return None
 		game_id = game_verify_by_name["id"]
 		game_media = self.rgc_get_media(game_id)
-		game_grid_url = next((grid["url"] for grid in game_media), None)
+		game_grid_url = next((grid["game"]["most_popular_media_url"] for grid in game_media), None)
 		if game_grid_url is None:
 			return None
 		return self.download_image(game_grid_url)

--- a/ice/gridproviders/retrogamingcloud_provider.py
+++ b/ice/gridproviders/retrogamingcloud_provider.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# encoding: utf-8
+"""
+retrogamingcloud_provider.py
+
+Created by W on 2017-06-13.
+Copyright (c) 2017 W Anders. All rights reserved.
+"""
+
+import sys
+import os
+import urllib
+import json
+
+import grid_image_provider
+
+from ice.logs import logger
+
+class RetroGamingCloudProvider(grid_image_provider.GridImageProvider):
+
+	@staticmethod
+	def is_enabled():
+		return True
+
+	@staticmethod
+	def api_url():
+		return "http://retrogaming.cloud/api/v1/game"
+
+	def download_image(self, url):
+		(path, headers) = urllib.urlretrieve(url)
+		return path
+
+	def rgc_get_result(self, url):
+		try:
+			response = urllib.urlopen(url)
+			return json.loads(response.read())["results"]
+		except IOError as error:
+			logger.debug(
+				"There was an error contacting Retrogaming.cloud"
+			)
+			return None
+
+	def rgc_search(self, rom):
+		api_root = self.api_url()
+		url = "%s?name=\"%s\"" % (api_root, rom.name)
+		return self.rgc_get_result(url)
+
+	def rgc_get_media(self, game_id):
+		api_root = self.api_url()
+		url = "%s/%s/media" % (api_root, game_id)
+		return self.rgc_get_result(url)
+
+	def image_for_rom(self, rom):
+		game_results = self.rgc_search(rom)
+		game_by_console = [game for game in game_results if game["platform"]["key"] == rom.console.shortname]
+		game_verify_by_name = next((game for game in game_by_console if game["name"] == rom.name), None)
+		if game_verify_by_name is None:
+			return None
+		game_id = game_verify_by_name["id"]
+		game_media = self.rgc_get_media(game_id)
+		game_grid_url = next((grid["url"] for grid in game_media), None)
+		if game_grid_url is None:
+			return None
+		return self.download_image(game_grid_url)

--- a/ice/settings.py
+++ b/ice/settings.py
@@ -10,6 +10,7 @@ from logs import logger
 from gridproviders.combined_provider import CombinedProvider
 from gridproviders.consolegrid_provider import ConsoleGridProvider
 from gridproviders.local_provider import LocalProvider
+from gridproviders.retrogamingcloud_provider import RetroGamingCloudProvider
 from persistence.backed_object_manager import BackedObjectManager
 from persistence.config_file_backing_store import ConfigFileBackingStore
 from persistence.adapters.console_adapter import ConsoleBackedObjectAdapter
@@ -73,6 +74,7 @@ def image_provider(config):
   providerByName = {
     "local": LocalProvider,
     "consolegrid": ConsoleGridProvider,
+    "retrogamingcloud": RetroGamingCloudProvider,
   }
   normalize = lambda s: s.strip().lower()
   names = map(normalize, config.provider_spec.split(","))


### PR DESCRIPTION
This aims to replace ConsoleGrid with Retrogaming.cloud as the grid image provider.
Has worked as intended on every ROM I've tested so far.

Two items to note, could be considered drawbacks associated with RG.C:

- Games have to be named exactly as the appear on the site. RG.C allows special characters that are not allowed in file paths, so a ROM name omitting a colon as a separator will fail to match (Eg.). This may be worked around by not using a literal search, but that seems to bring up many unrelated results.
- RG.C has an unspecified request rate limit. It appears to be around 150 per minute, but since 2 requests are required to retrieve the image URL, that number is half. Testing shows 70-80 ROM queries before the limit is triggered for an unspecified cool-down.

**(Repost of #467  since HEAD changed.)**