### PR TITLE
Updated shortcut constructor

### DIFF
--- a/ice/roms.py
+++ b/ice/roms.py
@@ -46,9 +46,15 @@ def rom_to_shortcut(rom):
   assert(emu is not None)
 
   return model.Shortcut(
-    name      = rom_shortcut_name(rom),
-    exe       = emulators.emulator_rom_launch_command(emu, rom),
-    startdir  = emulators.emulator_startdir(emu),
-    icon      = rom.console.icon,
-    tags      = [rom.console.fullname]
+    name                  = rom_shortcut_name(rom),
+    exe                   = emulators.emulator_rom_launch_command(emu, rom),
+    startdir              = emulators.emulator_startdir(emu),
+    icon                  = rom.console.icon,
+    shortcut_path         = "",
+    launch_options        = "",
+    hidden                = False,
+    allow_desktop_config  = True,
+    open_vr               = False,
+    last_play_time        = 0,
+    tags                  = [rom.console.fullname]
   )


### PR DESCRIPTION
Updated the method that calls the pysteam Shortcut constructor.
Requires #456 pysteam version 1.1 with new **shortcut.vdf** format.

Without updated #456 pysteam version, **shortcut.vdf** backups fail, and without these updates to the constructor call, Ice is unable to create new shortcuts with the updated version of pysteam.