### PR TITLE
Fixed Heading formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 ![Example of Ice](ice-example.png "Example")
 
-##Ice
+# Ice
 
-###Description
+## Description
 
 The purpose of this project is to leverage Steam's Big Picture mode to turn it into an emulator frontend (similar to Hyperspin). It accomplishes this by creating folders in specified locations on the user's hard drive, then adding any ROMs that are placed in these folders to Steam as non-Steam games. Emulators are installed and configured by the user before Ice is run.
 
-###License
+## License
 
 All of my code is licensed under MIT.
 
-###Getting Started
+## Getting Started
 
 Ice's official documentation is available at [Getting Started.](http://scottrice.github.io/Ice/getting-started/) 
 
-###Running the Source
+## Running the Source
 
 You will need Python 2.7 to run Ice. Python 3.0 and up will not work.
 
@@ -24,6 +24,6 @@ Next, you will need to download all of Ice's dependencies. To do so, run `python
 
 Once all of that is finished, simply run `python -m ice` from the repository's root directory.
 
-###Ice GUI
+## Ice GUI
 
 A GUI for Ice is currently being developed, but is very far from being production ready. As of writing, it is basically non-functional. Do not attempt to use the GUI, doing so will only bring you pain and heartache.


### PR DESCRIPTION
Markdown requires a space between the last '#' and the header text.  I also moved everything up a level so you don't start with H2